### PR TITLE
Kill old processing sketches when launching a new one

### DIFF
--- a/lib/processing.coffee
+++ b/lib/processing.coffee
@@ -1,6 +1,7 @@
 {CompositeDisposable, BufferedProcess} = require 'atom'
 fs = require 'fs'
 path = require 'path'
+psTree = require 'ps-tree'
 
 module.exports = Processing =
   config:
@@ -39,7 +40,13 @@ module.exports = Processing =
       console.error(output)
     exit = (code) ->
       console.log("Error code: #{code}")
-    process = new BufferedProcess({command, args, stdout, stderr, exit})
+
+    if @process
+      psTree @process.process.pid, (err, children) =>
+        console.log("Children", children)
+        for child in children
+          process.kill(child.PID)
+    @process = new BufferedProcess({command, args, stdout, stderr, exit})
 
   runSketch: ->
     @saveSketch()

--- a/lib/processing.coffee
+++ b/lib/processing.coffee
@@ -43,7 +43,6 @@ module.exports = Processing =
 
     if @process
       psTree @process.process.pid, (err, children) =>
-        console.log("Children", children)
         for child in children
           process.kill(child.PID)
     @process = new BufferedProcess({command, args, stdout, stderr, exit})

--- a/lib/processing.coffee
+++ b/lib/processing.coffee
@@ -30,7 +30,7 @@ module.exports = Processing =
     file    = editor?.buffer.file
     folder  = file.getParent().getPath()
     build_dir = path.join(folder, "build")
-    command = path.normalize(atom.config.get("processing.processing-executable"))
+    command = path.normalize(atom.config.get("processing-atom.processing-executable"))
     args = ["--sketch=#{folder}", "--output=#{build_dir}", "--run", "--force"]
     options = {}
     console.log("Running command #{command} #{args.join(" ")}")

--- a/package.json
+++ b/package.json
@@ -11,5 +11,7 @@
   "engines": {
     "atom": ">0.187.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "ps-tree": "^1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "processing",
+  "name": "processing-atom",
   "main": "./lib/processing",
   "version": "0.7.0",
   "description": "Run Processing sketches in Atom",
   "activationCommands": {
     "atom-workspace": "processing:run"
   },
-  "repository": "https://github.com/bleikamp/processing",
+  "repository": "https://github.com/msfeldstein/processing",
   "license": "MIT",
   "engines": {
     "atom": ">0.187.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "processing-atom",
   "main": "./lib/processing",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Run Processing sketches in Atom",
   "activationCommands": {
     "atom-workspace": "processing:run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "processing-atom",
   "main": "./lib/processing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Run Processing sketches in Atom",
   "activationCommands": {
     "atom-workspace": "processing:run"


### PR DESCRIPTION
I found that I would open up multiple processing sketches if i forgot to close the old one.  This will kill any old sketches that you're running when you start a new one so you always only have the latest running.