### PR TITLE
Moves --force arg to the beginning

### DIFF
--- a/lib/processing.coffee
+++ b/lib/processing.coffee
@@ -30,7 +30,7 @@ module.exports = Processing =
     folder  = file.getParent().getPath()
     build_dir = path.join(folder, "build")
     command = path.normalize(atom.config.get("processing.processing-executable"))
-    args = ["--sketch=#{folder}", "--output=#{build_dir}", "--run", "--force"]
+    args = ["--force", "--sketch=#{folder}", "--output=#{build_dir}", "--run"]
     options = {}
     console.log("Running command #{command} #{args.join(" ")}")
     stdout = (output) ->


### PR DESCRIPTION
In OSX, Processing 3 won't build new Sketch if a folder was already built. It only works when the --force arg is the first one.
Probably a P3 bug.