### PR TITLE
Add keymap support for macOS

### DIFF
--- a/keymaps/processing.cson
+++ b/keymaps/processing.cson
@@ -9,4 +9,6 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor':
   'ctrl-alt-b': 'processing:run'
+  'cmd-alt-b': 'processing:run'
   'ctrl-alt-c': 'processing:close'
+  'cmd-alt-c': 'processing:close'


### PR DESCRIPTION
The `ctrl`-keymaps didn't work on OSX and macOS. They do now because I also added the `cmd` versions.