### PR TITLE
Only invoke compilation if the file type is.pde, and if not, then simply hide the panel.

### DIFF
--- a/lib/processing.coffee
+++ b/lib/processing.coffee
@@ -49,6 +49,8 @@ module.exports = Processing =
       if !@view
         @view = new ProcessingView
         atom.workspace.addBottomPanel(item: @view)
+      else
+        atom.workspace.panelForItem(@view).show()
       if @process
         psTree @process.process.pid, (err, children) =>
           for child in children
@@ -57,7 +59,7 @@ module.exports = Processing =
       @process = new BufferedProcess({command, args, stdout, stderr, exit})
     else
       if @view
-        atom.workspace.panelForItem(@view).destroy()
+        atom.workspace.panelForItem(@view).hide()
 
 
   runSketch: ->

--- a/lib/processing.coffee
+++ b/lib/processing.coffee
@@ -33,25 +33,31 @@ module.exports = Processing =
     console.log("build and run time")
     editor  = atom.workspace.getActivePaneItem()
     file    = editor?.buffer.file
-    folder  = file.getParent().getPath()
-    build_dir = path.join(folder, "build")
-    command = path.normalize(atom.config.get("processing.processing-executable"))
-    args = ["--force", "--sketch=#{folder}", "--output=#{build_dir}", "--run"]
-    options = {}
-    console.log("Running command #{command} #{args.join(" ")}")
-    stdout = (output) => @display output
-    stderr = (output) => @display output
-    exit = (code) ->
-      console.log("Error code: #{code}")
-    if !@view
-      @view = new ProcessingView
-      atom.workspace.addBottomPanel(item: @view)
-    if @process
-      psTree @process.process.pid, (err, children) =>
-        for child in children
-          process.kill(child.PID)
-      @view.clear()
-    @process = new BufferedProcess({command, args, stdout, stderr, exit})
+    name    = file?.getBaseName()
+
+    if name.includes('.pde')
+      folder  = file.getParent().getPath()
+      build_dir = path.join(folder, "build-tmp")
+      command = path.normalize(atom.config.get("processing.processing-executable"))
+      args = ["--force", "--sketch=#{folder}", "--output=#{build_dir}", "--run"]
+      options = {}
+      console.log("Running command #{command} #{args.join(" ")}")
+      stdout = (output) => @display output
+      stderr = (output) => @display output
+      exit = (code) ->
+        console.log("Error code: #{code}")
+      if !@view
+        @view = new ProcessingView
+        atom.workspace.addBottomPanel(item: @view)
+      if @process
+        psTree @process.process.pid, (err, children) =>
+          for child in children
+            process.kill(child.PID)
+        @view.clear()
+      @process = new BufferedProcess({command, args, stdout, stderr, exit})
+    else
+      if @view
+        atom.workspace.panelForItem(@view).destroy()
 
 
   runSketch: ->


### PR DESCRIPTION
With this change (please feel free to refactor if it's messy - I've never written CoffeeScript before), the Processing compilation only happens if the current file is a .pde file, otherwise the command simply gets ignored. If the bottom panel is active from a previous Processing session, that panel also gets hidden away.

I found myself accidentally hitting cmd + R (my key-binding for Processing) and it would try to run the Processing compiler on HTML, CSS, C++ files and would result in the bottom panel opening up with an error, and with no way of hiding the panel away. Now, if the file isn't a .pde, the command will simply hide that panel.

Hope this helps.